### PR TITLE
Implement spaghetti plot speedup

### DIFF
--- a/SMHviz_plot/figures.py
+++ b/SMHviz_plot/figures.py
@@ -1060,7 +1060,6 @@ def add_spaghetti_plot(fig, df, color_dict, legend_dict=None,
         all_traj_df.loc[pd.isna(all_traj_df['value']), 'type_id'] = np.nan
 
         # Add single trace
-        connect_gaps = None
         color = re.sub(", 1\)", ", " + str(opacity) + ")", col_line[0])
         fig.add_trace(go.Scatter(x=all_traj_df['target_end_date'],
                                  y=all_traj_df['value'],
@@ -1077,8 +1076,6 @@ def add_spaghetti_plot(fig, df, color_dict, legend_dict=None,
                                                "Value: %{y:,.2f}<br>Epiweek: %{x|%Y-%m-%d}<extra></extra>"
                                                 ),
                       row=subplot_coord[0], col=subplot_coord[1])
-        if connect_gaps is not None:
-          fig.update_traces(connectgaps=connect_gaps)
         if add_median is True and df_med is not None:
             df_plot_med = df_med[df_med[legend_col] == leg]
             add_scatter_trace(fig, df_plot_med, legend_name, x_col="target_end_date", show_legend=False,

--- a/SMHviz_plot/figures.py
+++ b/SMHviz_plot/figures.py
@@ -1056,6 +1056,8 @@ def add_spaghetti_plot(fig, df, color_dict, legend_dict=None,
         temp.loc[:, 'target_end_date'] = [pd.NaT] * len(traj_list)
         all_traj_df = pd.concat([df_plot, temp], axis=0)
         all_traj_df = all_traj_df.sort_values(['type_id', 'target_end_date'])
+        # Once Nan's are inserted between typeIDs, insert Nan in type ID col so hover text renders correctly
+        all_traj_df.loc[pd.isna(all_traj_df['value']), 'type_id'] = np.nan
 
         # Add single trace
         connect_gaps = None
@@ -1069,7 +1071,9 @@ def add_spaghetti_plot(fig, df, color_dict, legend_dict=None,
                                  line=dict(width=2, dash=None),
                                  visible=True,
                                  showlegend=show_legend,
+                                 customdata=all_traj_df['type_id'],
                                  hovertemplate=hover_text + f"Model: {legend_name}<br>"
+                                               "Type ID: %{customdata}<br>"
                                                "Value: %{y:,.2f}<br>Epiweek: %{x|%Y-%m-%d}<extra></extra>"
                                                 ),
                       row=subplot_coord[0], col=subplot_coord[1])


### PR DESCRIPTION
Update figures.py with new add_spaghetti_plot function implementing all trajectories for a model in one trace, which provides a 10X speed up. 

Below is a brief overview of the timing differences (in seconds) between Method A (currently implemented) and Method B (adding all trajectories per model to one trace)

Method A
prep plot dictionary      0.042844
prep subplots  0.011879
scenario_1     0.218446
scenario_2     0.222543
scenario_3     0.220516
scenario_4     0.224168
scenario_5     0.226434
total_time     1.184734


New way
prep plot dictionary     0.040703
prep subplots  0.011307
scenario_1     0.019788
scenario_2     0.019364
scenario_3     0.019246
scenario_4     0.019799
scenario_5     0.019325
total_time     0.165057